### PR TITLE
Update ThreeCSG.js

### DIFF
--- a/ThreeCSG.js
+++ b/ThreeCSG.js
@@ -198,7 +198,7 @@ window.ThreeBSP = (function() {
 			mesh = new THREE.Mesh( geometry, material );
 		
 		mesh.position.getPositionFromMatrix( this.matrix );
-		mesh.rotation.setEulerFromRotationMatrix( this.matrix );
+		mesh.rotation.setFromRotationMatrix( this.matrix );
 		
 		return mesh;
 	};


### PR DESCRIPTION
On line 201, "setEulerFromRotationMatrix" kicks up errors in Firefox. However, dropping the word "Euler" fixes it. It should be,
setFromRotationMatrix
