### PR TITLE
Support r62

### DIFF
--- a/ThreeCSG.js
+++ b/ThreeCSG.js
@@ -198,7 +198,7 @@ window.ThreeBSP = (function() {
 			mesh = new THREE.Mesh( geometry, material );
 		
 		mesh.position.getPositionFromMatrix( this.matrix );
-		mesh.rotation.setEulerFromRotationMatrix( this.matrix );
+		mesh.rotation.setFromRotationMatrix( this.matrix );
 		
 		return mesh;
 	};


### PR DESCRIPTION
Since r59 the Oject3D's rotation is an instance of THREE.Euler. Therefore setEulerFromRotationMatrix must now be simply setFromRotationMatrix. Tested with the lastest r62.
