### PR TITLE
Use Vector3's setFromMatrixPosition if available

### DIFF
--- a/ThreeCSG.js
+++ b/ThreeCSG.js
@@ -197,11 +197,7 @@ window.ThreeBSP = (function() {
 		var geometry = this.toGeometry(),
 			mesh = new THREE.Mesh( geometry, material );
 		
-		if ( THREE.Vector3.prototype.setFromMatrixPosition ) {
-			mesh.position.setFromMatrixPosition( this.matrix );
-		} else {
-			mesh.position.getPositionFromMatrix( this.matrix );
-		}
+		mesh.position.setFromMatrixPosition( this.matrix );
 		mesh.rotation.setFromRotationMatrix( this.matrix );
 		
 		return mesh;


### PR DESCRIPTION
Vector3's .getPositionFromMatrix() has been renamed to .setFromMatrixPosition() in r64 (specifically in [this commit](https://github.com/mrdoob/three.js/commit/bb31515d6bae3d7ba10541f5ccaa490c72c1ac6e)).

Adding a conditional that uses the new name if it is available, and the old if not.
