### PR TITLE
Bugfix: wrong index for vertexNormals for face.b

### DIFF
--- a/ThreeCSG.js
+++ b/ThreeCSG.js
@@ -45,7 +45,7 @@ window.ThreeBSP = (function() {
 				
 				vertex = geometry.vertices[ face.b ];
                                 uvs = faceVertexUvs ? new THREE.Vector2( faceVertexUvs[1].x, faceVertexUvs[1].y ) : null;
-                                vertex = new ThreeBSP.Vertex( vertex.x, vertex.y, vertex.z, face.vertexNormals[2], uvs );
+                                vertex = new ThreeBSP.Vertex( vertex.x, vertex.y, vertex.z, face.vertexNormals[1], uvs );
 				vertex.applyMatrix4(this.matrix);
 				polygon.vertices.push( vertex );
 				


### PR DESCRIPTION
There was a bug in converting vertex normals for `THREE.Face3` faces. The index value used to collect the vertexNormalsfor vertex b (`face.b`) was 2 instead of 1, resulting in a wrong geometry.