### PR TITLE
#

### DIFF
--- a/ThreeCSG.js
+++ b/ThreeCSG.js
@@ -1,13 +1,13 @@
 'use strict';
 window.ThreeBSP = (function() {
-	
+
 	var ThreeBSP,
 		EPSILON = 1e-5,
 		COPLANAR = 0,
 		FRONT = 1,
 		BACK = 2,
 		SPANNING = 3;
-	
+
 	ThreeBSP = function( geometry ) {
 		// Convert THREE.Geometry to ThreeBSP
 		var i, _length_i,
@@ -15,7 +15,7 @@ window.ThreeBSP = (function() {
 			polygon,
 			polygons = [],
 			tree;
-	
+
 		if ( geometry instanceof THREE.Geometry ) {
 			this.matrix = new THREE.Matrix4;
 		} else if ( geometry instanceof THREE.Mesh ) {
@@ -30,25 +30,25 @@ window.ThreeBSP = (function() {
 		} else {
 			throw 'ThreeBSP: Given geometry is unsupported';
 		}
-	
+
 		for ( i = 0, _length_i = geometry.faces.length; i < _length_i; i++ ) {
 			face = geometry.faces[i];
 			faceVertexUvs = geometry.faceVertexUvs[0][i];
 			polygon = new ThreeBSP.Polygon;
-			
+
 			if ( face instanceof THREE.Face3 ) {
 				vertex = geometry.vertices[ face.a ];
                                 uvs = faceVertexUvs ? new THREE.Vector2( faceVertexUvs[0].x, faceVertexUvs[0].y ) : null;
                                 vertex = new ThreeBSP.Vertex( vertex.x, vertex.y, vertex.z, face.vertexNormals[0], uvs );
 				vertex.applyMatrix4(this.matrix);
 				polygon.vertices.push( vertex );
-				
+
 				vertex = geometry.vertices[ face.b ];
                                 uvs = faceVertexUvs ? new THREE.Vector2( faceVertexUvs[1].x, faceVertexUvs[1].y ) : null;
                                 vertex = new ThreeBSP.Vertex( vertex.x, vertex.y, vertex.z, face.vertexNormals[1], uvs );
 				vertex.applyMatrix4(this.matrix);
 				polygon.vertices.push( vertex );
-				
+
 				vertex = geometry.vertices[ face.c ];
                                 uvs = faceVertexUvs ? new THREE.Vector2( faceVertexUvs[2].x, faceVertexUvs[2].y ) : null;
                                 vertex = new ThreeBSP.Vertex( vertex.x, vertex.y, vertex.z, face.vertexNormals[2], uvs );
@@ -60,19 +60,19 @@ window.ThreeBSP = (function() {
                                 vertex = new ThreeBSP.Vertex( vertex.x, vertex.y, vertex.z, face.vertexNormals[0], uvs );
 				vertex.applyMatrix4(this.matrix);
 				polygon.vertices.push( vertex );
-				
+
 				vertex = geometry.vertices[ face.b ];
                                 uvs = faceVertexUvs ? new THREE.Vector2( faceVertexUvs[1].x, faceVertexUvs[1].y ) : null;
                                 vertex = new ThreeBSP.Vertex( vertex.x, vertex.y, vertex.z, face.vertexNormals[1], uvs );
 				vertex.applyMatrix4(this.matrix);
 				polygon.vertices.push( vertex );
-				
+
 				vertex = geometry.vertices[ face.c ];
                                 uvs = faceVertexUvs ? new THREE.Vector2( faceVertexUvs[2].x, faceVertexUvs[2].y ) : null;
                                 vertex = new ThreeBSP.Vertex( vertex.x, vertex.y, vertex.z, face.vertexNormals[2], uvs );
 				vertex.applyMatrix4(this.matrix);
 				polygon.vertices.push( vertex );
-				
+
 				vertex = geometry.vertices[ face.d ];
                                 uvs = faceVertexUvs ? new THREE.Vector2( faceVertexUvs[3].x, faceVertexUvs[3].y ) : null;
                                 vertex = new ThreeBSP.Vertex( vertex.x, vertex.y, vertex.z, face.vertexNormals[3], uvs );
@@ -81,17 +81,17 @@ window.ThreeBSP = (function() {
 			} else {
 				throw 'Invalid face type at index ' + i;
 			}
-			
+
 			polygon.calculateProperties();
 			polygons.push( polygon );
 		};
-	
+
 		this.tree = new ThreeBSP.Node( polygons );
 	};
 	ThreeBSP.prototype.subtract = function( other_tree ) {
 		var a = this.tree.clone(),
 			b = other_tree.tree.clone();
-		
+
 		a.invert();
 		a.clipTo( b );
 		b.clipTo( a );
@@ -107,7 +107,7 @@ window.ThreeBSP = (function() {
 	ThreeBSP.prototype.union = function( other_tree ) {
 		var a = this.tree.clone(),
 			b = other_tree.tree.clone();
-		
+
 		a.clipTo( b );
 		b.clipTo( a );
 		b.invert();
@@ -121,7 +121,7 @@ window.ThreeBSP = (function() {
 	ThreeBSP.prototype.intersect = function( other_tree ) {
 		var a = this.tree.clone(),
 			b = other_tree.tree.clone();
-		
+
 		a.invert();
 		b.clipTo( a );
 		b.invert();
@@ -144,26 +144,26 @@ window.ThreeBSP = (function() {
 			vertex_idx_a, vertex_idx_b, vertex_idx_c,
 			vertex, face,
 			verticeUvs;
-	
+
 		for ( i = 0; i < polygon_count; i++ ) {
 			polygon = polygons[i];
 			polygon_vertice_count = polygon.vertices.length;
-			
+
 			for ( j = 2; j < polygon_vertice_count; j++ ) {
 				verticeUvs = [];
-				
+
 				vertex = polygon.vertices[0];
 				verticeUvs.push( new THREE.Vector2( vertex.uv.x, vertex.uv.y ) );
 				vertex = new THREE.Vector3( vertex.x, vertex.y, vertex.z );
 				vertex.applyMatrix4(matrix);
-				
+
 				if ( typeof vertice_dict[ vertex.x + ',' + vertex.y + ',' + vertex.z ] !== 'undefined' ) {
 					vertex_idx_a = vertice_dict[ vertex.x + ',' + vertex.y + ',' + vertex.z ];
 				} else {
 					geometry.vertices.push( vertex );
 					vertex_idx_a = vertice_dict[ vertex.x + ',' + vertex.y + ',' + vertex.z ] = geometry.vertices.length - 1;
 				}
-				
+
 				vertex = polygon.vertices[j-1];
 				verticeUvs.push( new THREE.Vector2( vertex.uv.x, vertex.uv.y ) );
 				vertex = new THREE.Vector3( vertex.x, vertex.y, vertex.z );
@@ -174,7 +174,7 @@ window.ThreeBSP = (function() {
 					geometry.vertices.push( vertex );
 					vertex_idx_b = vertice_dict[ vertex.x + ',' + vertex.y + ',' + vertex.z ] = geometry.vertices.length - 1;
 				}
-				
+
 				vertex = polygon.vertices[j];
 				verticeUvs.push( new THREE.Vector2( vertex.uv.x, vertex.uv.y ) );
 				vertex = new THREE.Vector3( vertex.x, vertex.y, vertex.z );
@@ -185,37 +185,37 @@ window.ThreeBSP = (function() {
 					geometry.vertices.push( vertex );
 					vertex_idx_c = vertice_dict[ vertex.x + ',' + vertex.y + ',' + vertex.z ] = geometry.vertices.length - 1;
 				}
-				
+
 				face = new THREE.Face3(
 					vertex_idx_a,
 					vertex_idx_b,
 					vertex_idx_c,
 					new THREE.Vector3( polygon.normal.x, polygon.normal.y, polygon.normal.z )
 				);
-				
+
 				geometry.faces.push( face );
 				geometry.faceVertexUvs[0].push( verticeUvs );
 			}
-			
+
 		}
 		return geometry;
 	};
 	ThreeBSP.prototype.toMesh = function( material ) {
 		var geometry = this.toGeometry(),
 			mesh = new THREE.Mesh( geometry, material );
-		
+
 		mesh.position.setFromMatrixPosition( this.matrix );
 		mesh.rotation.setFromRotationMatrix( this.matrix );
-		
+
 		return mesh;
 	};
-	
-	
+
+
 	ThreeBSP.Polygon = function( vertices, normal, w ) {
 		if ( !( vertices instanceof Array ) ) {
 			vertices = [];
 		}
-		
+
 		this.vertices = vertices;
 		if ( vertices.length > 0 ) {
 			this.calculateProperties();
@@ -227,43 +227,43 @@ window.ThreeBSP = (function() {
 		var a = this.vertices[0],
 			b = this.vertices[1],
 			c = this.vertices[2];
-			
+
 		this.normal = b.clone().subtract( a ).cross(
 			c.clone().subtract( a )
 		).normalize();
-		
+
 		this.w = this.normal.clone().dot( a );
-		
+
 		return this;
 	};
 	ThreeBSP.Polygon.prototype.clone = function() {
 		var i, vertice_count,
 			polygon = new ThreeBSP.Polygon;
-		
+
 		for ( i = 0, vertice_count = this.vertices.length; i < vertice_count; i++ ) {
 			polygon.vertices.push( this.vertices[i].clone() );
 		};
 		polygon.calculateProperties();
-		
+
 		return polygon;
 	};
-	
+
 	ThreeBSP.Polygon.prototype.flip = function() {
 		var i, vertices = [];
-		
+
 		this.normal.multiplyScalar( -1 );
 		this.w *= -1;
-		
+
 		for ( i = this.vertices.length - 1; i >= 0; i-- ) {
 			vertices.push( this.vertices[i] );
 		};
 		this.vertices = vertices;
-		
+
 		return this;
 	};
-	ThreeBSP.Polygon.prototype.classifyVertex = function( vertex ) {  
+	ThreeBSP.Polygon.prototype.classifyVertex = function( vertex ) {
 		var side_value = this.normal.dot( vertex ) - this.w;
-		
+
 		if ( side_value < -EPSILON ) {
 			return BACK;
 		} else if ( side_value > EPSILON ) {
@@ -277,7 +277,7 @@ window.ThreeBSP = (function() {
 			num_positive = 0,
 			num_negative = 0,
 			vertice_count = polygon.vertices.length;
-		
+
 		for ( i = 0; i < vertice_count; i++ ) {
 			vertex = polygon.vertices[i];
 			classification = this.classifyVertex( vertex );
@@ -287,7 +287,7 @@ window.ThreeBSP = (function() {
 				num_negative++;
 			}
 		}
-		
+
 		if ( num_positive > 0 && num_negative === 0 ) {
 			return FRONT;
 		} else if ( num_positive === 0 && num_negative > 0 ) {
@@ -300,35 +300,35 @@ window.ThreeBSP = (function() {
 	};
 	ThreeBSP.Polygon.prototype.splitPolygon = function( polygon, coplanar_front, coplanar_back, front, back ) {
 		var classification = this.classifySide( polygon );
-		
+
 		if ( classification === COPLANAR ) {
-			
+
 			( this.normal.dot( polygon.normal ) > 0 ? coplanar_front : coplanar_back ).push( polygon );
-			
+
 		} else if ( classification === FRONT ) {
-			
+
 			front.push( polygon );
-			
+
 		} else if ( classification === BACK ) {
-			
+
 			back.push( polygon );
-			
+
 		} else {
-			
+
 			var vertice_count,
 				i, j, ti, tj, vi, vj,
 				t, v,
 				f = [],
 				b = [];
-			
+
 			for ( i = 0, vertice_count = polygon.vertices.length; i < vertice_count; i++ ) {
-				
+
 				j = (i + 1) % vertice_count;
 				vi = polygon.vertices[i];
 				vj = polygon.vertices[j];
 				ti = this.classifyVertex( vi );
 				tj = this.classifyVertex( vj );
-				
+
 				if ( ti != BACK ) f.push( vi );
 				if ( ti != FRONT ) b.push( vi );
 				if ( (ti | tj) === SPANNING ) {
@@ -338,13 +338,13 @@ window.ThreeBSP = (function() {
 					b.push( v );
 				}
 			}
-			
-			
+
+
 			if ( f.length >= 3 ) front.push( new ThreeBSP.Polygon( f ).calculateProperties() );
 			if ( b.length >= 3 ) back.push( new ThreeBSP.Polygon( b ).calculateProperties() );
 		}
 	};
-	
+
 	ThreeBSP.Vertex = function( x, y, z, normal, uv ) {
 		this.x = x;
 		this.y = y;
@@ -381,16 +381,16 @@ window.ThreeBSP = (function() {
 		this.x = y * vertex.z - z * vertex.y;
 		this.y = z * vertex.x - x * vertex.z;
 		this.z = x * vertex.y - y * vertex.x;
-		
+
 		return this;
 	};
 	ThreeBSP.Vertex.prototype.normalize = function() {
 		var length = Math.sqrt( this.x * this.x + this.y * this.y + this.z * this.z );
-		
+
 		this.x /= length;
 		this.y /= length;
 		this.z /= length;
-		
+
 		return this;
 	};
 	ThreeBSP.Vertex.prototype.dot = function( vertex ) {
@@ -400,15 +400,15 @@ window.ThreeBSP = (function() {
 		this.add(
 			a.clone().subtract( this ).multiplyScalar( t )
 		);
-		
+
 		this.normal.add(
 			a.normal.clone().sub( this.normal ).multiplyScalar( t )
 		);
-		
+
 		this.uv.add(
 			a.uv.clone().sub( this.uv ).multiplyScalar( t )
 		);
-		
+
 		return this;
 	};
 	ThreeBSP.Vertex.prototype.interpolate = function( other, t ) {
@@ -429,8 +429,8 @@ window.ThreeBSP = (function() {
 		return this;
 
 	}
-	
-	
+
+
 	ThreeBSP.Node = function( polygons ) {
 		var i, polygon_count,
 			front = [],
@@ -438,19 +438,19 @@ window.ThreeBSP = (function() {
 
 		this.polygons = [];
 		this.front = this.back = undefined;
-		
+
 		if ( !(polygons instanceof Array) || polygons.length === 0 ) return;
 
 		this.divider = polygons[0].clone();
-		
+
 		for ( i = 0, polygon_count = polygons.length; i < polygon_count; i++ ) {
 			this.divider.splitPolygon( polygons[i], this.polygons, this.polygons, front, back );
-		}   
-		
+		}
+
 		if ( front.length > 0 ) {
 			this.front = new ThreeBSP.Node( front );
 		}
-		
+
 		if ( back.length > 0 ) {
 			this.back = new ThreeBSP.Node( back );
 		}
@@ -470,20 +470,20 @@ window.ThreeBSP = (function() {
 		var i, polygon_count,
 			front = [],
 			back = [];
-		
+
 		if ( !this.divider ) {
 			this.divider = polygons[0].clone();
 		}
 
 		for ( i = 0, polygon_count = polygons.length; i < polygon_count; i++ ) {
 			this.divider.splitPolygon( polygons[i], this.polygons, this.polygons, front, back );
-		}   
-		
+		}
+
 		if ( front.length > 0 ) {
 			if ( !this.front ) this.front = new ThreeBSP.Node();
 			this.front.build( front );
 		}
-		
+
 		if ( back.length > 0 ) {
 			if ( !this.back ) this.back = new ThreeBSP.Node();
 			this.back.build( back );
@@ -497,29 +497,29 @@ window.ThreeBSP = (function() {
 	};
 	ThreeBSP.Node.prototype.clone = function() {
 		var node = new ThreeBSP.Node();
-		
+
 		node.divider = this.divider.clone();
 		node.polygons = this.polygons.map( function( polygon ) { return polygon.clone(); } );
 		node.front = this.front && this.front.clone();
 		node.back = this.back && this.back.clone();
-		
+
 		return node;
 	};
 	ThreeBSP.Node.prototype.invert = function() {
 		var i, polygon_count, temp;
-		
+
 		for ( i = 0, polygon_count = this.polygons.length; i < polygon_count; i++ ) {
 			this.polygons[i].flip();
 		}
-		
+
 		this.divider.flip();
 		if ( this.front ) this.front.invert();
 		if ( this.back ) this.back.invert();
-		
+
 		temp = this.front;
 		this.front = this.back;
 		this.back = temp;
-		
+
 		return this;
 	};
 	ThreeBSP.Node.prototype.clipPolygons = function( polygons ) {
@@ -527,9 +527,9 @@ window.ThreeBSP = (function() {
 			front, back;
 
 		if ( !this.divider ) return polygons.slice();
-		
+
 		front = [], back = [];
-		
+
 		for ( i = 0, polygon_count = polygons.length; i < polygon_count; i++ ) {
 			this.divider.splitPolygon( polygons[i], front, back, front, back );
 		}
@@ -540,13 +540,13 @@ window.ThreeBSP = (function() {
 
 		return front.concat( back );
 	};
-	
+
 	ThreeBSP.Node.prototype.clipTo = function( node ) {
 		this.polygons = node.clipPolygons( this.polygons );
 		if ( this.front ) this.front.clipTo( node );
 		if ( this.back ) this.back.clipTo( node );
 	};
-	
-	
+
+
 	return ThreeBSP;
 })();

--- a/examples.html
+++ b/examples.html
@@ -4,120 +4,136 @@
 
 <head>
 
-<script type="text/javascript" src="https://rawgit.com/mrdoob/three.js/master/build/three.min.js"></script>
-<script type="text/javascript" src="ThreeCSG.js"></script>
+	<script type="text/javascript" src="https://rawgit.com/mrdoob/three.js/master/build/three.min.js"></script>
+	<script type="text/javascript" src="threeCSG.js"></script>
 
-<script type="text/javascript">
-var renderer, scene, camera, light;
+	<script type="text/javascript">
+		var renderer, scene, camera, light;
 
-window.onload = function() {
-	
-	renderer = new THREE.WebGLRenderer({antialias: true});
-	renderer.setSize( window.innerWidth, window.innerHeight );
-	document.getElementById('viewport').appendChild(renderer.domElement);
-	
-	scene = new THREE.Scene();
-	
-	light = new THREE.DirectionalLight( 0xffffff );
-	light.position.set( 1, 1, 1 ).normalize();
-	scene.add( light );
-	
-	camera = new THREE.PerspectiveCamera(
-		35,
-		window.innerWidth / window.innerHeight,
-		1,
-		1000
-	);
-	camera.position.set( 5, 5, 15 );
-	camera.lookAt( scene.position );
-	scene.add( camera );
+		window.onload = function() {
 
-	// Example #1 - Cube (mesh) subtract Sphere (mesh)
-	(function() {
-		var start_time = (new Date()).getTime();
+			renderer = new THREE.WebGLRenderer({
+				antialias: true
+			});
+			renderer.setSize(window.innerWidth, window.innerHeight);
+			document.getElementById('viewport').appendChild(renderer.domElement);
 
-		var cube_geometry = new THREE.CubeGeometry( 3, 3, 3 );
-		var cube_mesh = new THREE.Mesh( cube_geometry );
-		cube_mesh.position.x = -7;
-		var cube_bsp = new ThreeBSP( cube_mesh );
+			scene = new THREE.Scene();
 
-		var sphere_geometry = new THREE.SphereGeometry( 1.8, 32, 32 );
-		var sphere_mesh = new THREE.Mesh( sphere_geometry );
-		sphere_mesh.position.x = -7;
-		var sphere_bsp = new ThreeBSP( sphere_mesh );
-		
-		var subtract_bsp = cube_bsp.subtract( sphere_bsp );
-		var result = subtract_bsp.toMesh( new THREE.MeshLambertMaterial({ shading: THREE.SmoothShading, map: THREE.ImageUtils.loadTexture('texture.png') }) );
-		result.geometry.computeVertexNormals();
-		scene.add( result );
+			light = new THREE.DirectionalLight(0xffffff);
+			light.position.set(1, 1, 1).normalize();
+			scene.add(light);
 
-		console.log( 'Example 1: ' + ((new Date()).getTime() - start_time) + 'ms' );
-	})();
+			camera = new THREE.PerspectiveCamera(
+				35,
+				window.innerWidth / window.innerHeight,
+				1,
+				1000
+			);
+			camera.position.set(5, 5, 15);
+			camera.lookAt(scene.position);
+			scene.add(camera);
 
-	// Example #2 - Sphere (geometry) union Cube (geometry)
-	(function() {
-		var start_time = (new Date()).getTime();
+			// Example #1 - Cube (mesh) subtract Sphere (mesh)
+			(function() {
+				var start_time = (new Date()).getTime();
 
-		var sphere_geometry = new THREE.SphereGeometry( 2, 16, 16 );
-		var sphere_bsp = new ThreeBSP( sphere_geometry );
-		
-		var cube_geometry = new THREE.CubeGeometry( 7, .5, 3 );
-		var cube_bsp = new ThreeBSP( cube_geometry );
-		
-		var union_bsp = sphere_bsp.union( cube_bsp );
-		
-		var result = union_bsp.toMesh( new THREE.MeshLambertMaterial({ shading: THREE.SmoothShading, map: THREE.ImageUtils.loadTexture('texture.png') }) );
-		result.geometry.computeVertexNormals();
-		scene.add( result );
+				var cube_geometry = new THREE.CubeGeometry(3, 3, 3);
+				var cube_mesh = new THREE.Mesh(cube_geometry);
+				cube_mesh.position.x = -7;
+				var cube_bsp = new ThreeBSP(cube_mesh);
 
-		console.log( 'Example 2: ' + ((new Date()).getTime() - start_time) + 'ms' );
-	})();
-	
-	
-	// Example #3 - Sphere (geometry) intersect Sphere (mesh)
-	(function() {
-		var start_time = (new Date()).getTime();
+				var sphere_geometry = new THREE.SphereGeometry(1.8, 32, 32);
+				var sphere_mesh = new THREE.Mesh(sphere_geometry);
+				sphere_mesh.position.x = -7;
+				var sphere_bsp = new ThreeBSP(sphere_mesh);
 
-		var sphere_geometry_1 = new THREE.SphereGeometry( 2, 64, 8 );
-		var sphere_bsp_1 = new ThreeBSP( sphere_geometry_1 );
-		
-		var sphere_geometry_2 = new THREE.SphereGeometry( 2, 8, 32 );
-		var sphere_mesh_2 = new THREE.Mesh( sphere_geometry_2 );
-		sphere_mesh_2.position.x = 2;
-		var sphere_bsp_2 = new ThreeBSP( sphere_mesh_2 );
-		
-		var intersect_bsp = sphere_bsp_1.intersect( sphere_bsp_2 );
-		
-		var result = intersect_bsp.toMesh( new THREE.MeshLambertMaterial({ shading: THREE.SmoothShading, map: THREE.ImageUtils.loadTexture('texture.png') }) );
-		result.position.x = 6;
-		result.geometry.computeVertexNormals();
-		scene.add( result );
+				var subtract_bsp = cube_bsp.subtract(sphere_bsp);
 
-		console.log( 'Example 3: ' + ((new Date()).getTime() - start_time) + 'ms' );
-	})();
+				var result = subtract_bsp.toMesh(new THREE.MeshLambertMaterial({
+					shading: THREE.SmoothShading,
+					map: new THREE.TextureLoader().load('texture.png')
+				}));
 
-	(function render() {
-		requestAnimationFrame( render );
-		renderer.render(scene, camera);
-	})();
-}
+				result.geometry.computeVertexNormals();
+				scene.add(result);
 
-</script>
+				console.log('Example 1: ' + ((new Date()).getTime() - start_time) + 'ms');
+			})();
 
-<style type="text/css">
-	html, body {
-		margin: 0;
-		padding: 0;
-		overflow: hidden;
-	}
-</style>
+			// Example #2 - Sphere (geometry) union Cube (geometry)
+			(function() {
+				var start_time = (new Date()).getTime();
+
+				var sphere_geometry = new THREE.SphereGeometry(2, 16, 16);
+				var sphere_bsp = new ThreeBSP(sphere_geometry);
+
+				var cube_geometry = new THREE.CubeGeometry(7, .5, 3);
+				var cube_bsp = new ThreeBSP(cube_geometry);
+
+				var union_bsp = sphere_bsp.union(cube_bsp);
+
+				var result = union_bsp.toMesh(new THREE.MeshLambertMaterial({
+					shading: THREE.SmoothShading,
+					map: new THREE.TextureLoader().load('texture.png')
+				}));
+
+				result.geometry.computeVertexNormals();
+				scene.add(result);
+
+				console.log('Example 2: ' + ((new Date()).getTime() - start_time) + 'ms');
+			})();
+
+
+			// Example #3 - Sphere (geometry) intersect Sphere (mesh)
+			(function() {
+				var start_time = (new Date()).getTime();
+
+				var sphere_geometry_1 = new THREE.SphereGeometry(2, 64, 8);
+				var sphere_bsp_1 = new ThreeBSP(sphere_geometry_1);
+
+				var sphere_geometry_2 = new THREE.SphereGeometry(2, 8, 32);
+				var sphere_mesh_2 = new THREE.Mesh(sphere_geometry_2);
+				sphere_mesh_2.position.x = 2;
+				var sphere_bsp_2 = new ThreeBSP(sphere_mesh_2);
+
+				var intersect_bsp = sphere_bsp_1.intersect(sphere_bsp_2);
+
+				var result = intersect_bsp.toMesh(new THREE.MeshLambertMaterial({
+					shading: THREE.SmoothShading,
+					map: new THREE.TextureLoader().load('texture.png')
+				}));
+
+
+				result.position.x = 6;
+				result.geometry.computeVertexNormals();
+				scene.add(result);
+
+				console.log('Example 3: ' + ((new Date()).getTime() - start_time) + 'ms');
+			})();
+
+			(function render() {
+				requestAnimationFrame(render);
+				renderer.render(scene, camera);
+			})();
+		}
+	</script>
+
+	<style type="text/css">
+		html,
+		body {
+			margin: 0;
+			padding: 0;
+			overflow: hidden;
+		}
+	</style>
 
 </head>
 
 <body>
-    
+
 	<div id="viewport"></div>
-	
+
 </body>
 
 </html>

--- a/threeCSG.es6
+++ b/threeCSG.es6
@@ -4,7 +4,7 @@ const EPSILON = 1e-5,
     FRONT = 1,
     BACK = 2,
     SPANNING = 3;
-export default class ThreeBSP {
+class ThreeBSP {
     constructor(geometry) {
         // Convert THREE.Geometry to ThreeBSP
         var i, _length_i,
@@ -205,7 +205,7 @@ export default class ThreeBSP {
         return geometry;
     }
 
-    toMesh = function (material) {
+    toMesh (material) {
         var geometry = this.toGeometry(),
             mesh = new THREE.Mesh(geometry, material);
 


### PR DESCRIPTION
# Tiny changes to clear warning messages and get the ES6 version running properly.
# examples.js
#     ImageUtils() has been deprecated. Used TextureLoader() instead.
#
# threeCSG.es6
#     removed the 'export default' declarations
#     fixed the 'toMesh' method declaration