### PR TITLE
Incorrect classification calculation in classifySide

### DIFF
--- a/ThreeCSG.js
+++ b/ThreeCSG.js
@@ -288,15 +288,15 @@ window.ThreeBSP = (function() {
 			}
 		}
 		
-		if ( num_positive > 0 && num_negative === 0 ) {
-			return FRONT;
-		} else if ( num_positive === 0 && num_negative > 0 ) {
-			return BACK;
-		} else if ( num_positive === 0 && num_negative === 0 ) {
-			return COPLANAR;
-		} else {
-			return SPANNING;
-		}
+        if ( num_positive === vertice_count && num_negative === 0 ) {
+            return FRONT;
+        } else if ( num_positive === 0 && num_negative === vertice_count ) {
+            return BACK;
+        } else if ( num_positive > 0 && num_negative > 0 ) {
+            return SPANNING;
+        } else {
+            return COPLANAR;
+        }
 	};
 	ThreeBSP.Polygon.prototype.splitPolygon = function( polygon, coplanar_front, coplanar_back, front, back ) {
 		var classification = this.classifySide( polygon );

--- a/threeCSG.es6
+++ b/threeCSG.es6
@@ -299,14 +299,14 @@ class Polygon {
             }
         }
 
-        if (num_positive > 0 && num_negative === 0) {
+        if (num_positive === vertice_count && num_negative === 0) {
             return FRONT;
-        } else if (num_positive === 0 && num_negative > 0) {
+        } else if (num_positive === 0 && num_negative === vertice_count) {
             return BACK;
-        } else if (num_positive === 0 && num_negative === 0) {
-            return COPLANAR;
-        } else {
+        } else if (num_positive > 0 && num_negative > 0) {
             return SPANNING;
+        } else {
+            return COPLANAR;
         }
     }
 


### PR DESCRIPTION
From https://en.wikipedia.org/wiki/Binary_space_partitioning : 

> 1. If that polygon is **wholly** in front of the plane containing P, move that polygon to the list of nodes in front of P.
> 2. If that polygon is **wholly** behind the plane containing P, move that polygon to the list of nodes behind P.

I ran into a bug where polygons being partially coplanar would cause an infinite recursion / stack overflow, so I updated classifyBySide to only classify as front or back if polygon is wholly in front of or behind the divider plane.