### PR TITLE
Fix THREE.CubeGeometry is not a constructor

### DIFF
--- a/examples.html
+++ b/examples.html
@@ -4,7 +4,7 @@
 
 <head>
 
-<script type="text/javascript" src="https://rawgit.com/mrdoob/three.js/master/build/three.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r122/three.min.js"></script>
 <script type="text/javascript" src="ThreeCSG.js"></script>
 
 <script type="text/javascript">


### PR DESCRIPTION
This error:

> THREE.CubeGeometry is not a constructor

Fixed according to:

https://stackoverflow.com/a/68000360/3405291